### PR TITLE
re-activate chunked-calling.

### DIFF
--- a/human/toil-scripts/call.sh
+++ b/human/toil-scripts/call.sh
@@ -65,7 +65,7 @@ while getopts "b:re:c:f:apv:s:l:" o; do
 				CHR_PREFIX=""
 				;;
 		  v)
-				VCF_OPTS="--genotype_vcf ${OPTARG} --call_chunk_size 0 --pack"
+				VCF_OPTS="--genotype_vcf ${OPTARG}  --pack"
 				;;
 		  s)
 				SNARL_OPTS="--snarls ${OPTARG}"


### PR DESCRIPTION
toil-vg really needs to be changed to efficiently take advantage of new caller.  for now, just use the old chunking logic as it works.  the readmes contain some examples on how to call without toil-vg (they way used for the timing benchmarks in the paper)