### PR TITLE
More toil-vg changes

### DIFF
--- a/human/chmpd/README.md
+++ b/human/chmpd/README.md
@@ -45,7 +45,7 @@ Using the helper scripts from `../toil-scripts`.
 # map the 30x reads and call variants
 ./map.sh -c ${CLUSTER} ${JOBSTORE} ${OUTSTORE}/CHMPD/map-PSEUDOSET s3://${OUTSTORE}/CHMPD PSEUDOSET ${FQBASE}/aln_30x.gam
 
-./call.sh -c ${CLUSTER} -v s3://${OUTSTORE}/CHMPD/pseudo_diploid.vcf.gz  -l s3://${OUTSTORE}/CHMPD/CHMPD_alts.gam ${JOBSTORE} ${OUTSTORE}/CHMPD/call-PSEUDOSET s3://${OUTSTORE}/CHMPD/CHMPD.xg PSEUDOSET s3://${OUTSTORE}/CHMPD/map-PSEUDOSET/PSEUDOSET_chr
+./call.sh -c ${CLUSTER} -v s3://${OUTSTORE}/CHMPD/pseudo_diploid.vcf.gz  ${JOBSTORE} ${OUTSTORE}/CHMPD/call-PSEUDOSET s3://${OUTSTORE}/CHMPD/CHMPD.xg PSEUDOSET s3://${OUTSTORE}/CHMPD/map-PSEUDOSET/PSEUDOSET_chr
 ```
 
 ## SMRT-SV v2

--- a/human/giab/README.md
+++ b/human/giab/README.md
@@ -31,7 +31,7 @@ Using the helper scripts from `../toil-scripts`.
 # map our downsampled 50X reads and call variants
 ./map.sh -c ${CLUSTER} ${JOBSTORE} ${OUTSTORE}/GIAB-0.5/map-HG002 s3://${OUTSTORE}/GIAB-0.5/GIAB HG002 ${FQBASE}/HG002-NA24385-50x.bam
 
-./call.sh -c ${CLUSTER} -v s3://${OUTSTORE}/GIAB-0.5/giab-0.5.vcf.gz -s s3://${OUTSTORE}/GIAB-0.5/GIAB.snarls -l s3://${OUTSTORE}/GIAB-0.5/GIAB_alts.gam ${JOBSTORE} ${OUTSTORE}/GIAB-0.5/call-HG002 s3://${OUTSTORE}/GIAB-0.5/GIAB.xg HG002 s3://${OUTSTORE}/GIAB-0.5/map-HG002/HG002_chr
+./call.sh -c ${CLUSTER} -v s3://${OUTSTORE}/GIAB-0.5/giab-0.5.vcf.gz -s s3://${OUTSTORE}/GIAB-0.5/GIAB.snarls  ${JOBSTORE} ${OUTSTORE}/GIAB-0.5/call-HG002 s3://${OUTSTORE}/GIAB-0.5/GIAB.xg HG002 s3://${OUTSTORE}/GIAB-0.5/map-HG002/HG002_chr
 
 ```
 

--- a/human/hgsvc/README.md
+++ b/human/hgsvc/README.md
@@ -47,16 +47,16 @@ Using the helper scripts from `../toil-scripts`.
 ## Use -M SKIP, -C SKIP, -E SKIP to bypass mapping, calling, evaluation respectively (ex, if rerunning a step)
 # Simulation
 ./map.sh -c ${CLUSTER}  ${JOBSTORE} ${OUTSTORE}/HGSVC/map-HG00514-sim s3://${OUTSTORE}/HGSVC HG00514 s3://${OUTSTORE}/HGSVC-chroms-dec5/sim/sim-HG00514-30x.fq.gz
-./call.sh -c ${CLUSTER} -v s3://${OUTSTORE}/HGSVC/HGSVC.haps.vcf.gz -l s3://${OUTSTORE}/HGSVC/HGSVC_alts.gam ${JOBSTORE} ${OUTSTORE}/HGSVC/call-HG00514-sim s3://${OUTSTORE}/HGSVC/HGSVC.xg HG00514 s3://${OUTSTORE}/HGSVC/map-HG00514-sim/HG00514_chr
+./call.sh -c ${CLUSTER} -v s3://${OUTSTORE}/HGSVC/HGSVC.haps.vcf.gz ${JOBSTORE} ${OUTSTORE}/HGSVC/call-HG00514-sim s3://${OUTSTORE}/HGSVC/HGSVC.xg HG00514 s3://${OUTSTORE}/HGSVC/map-HG00514-sim/HG00514_chr
 
 # Three HGSVC Samples (the reads can be found publicly by looking up the run names on EBI's ENA.  I had them mirrored in FQBASE for faster access)
 ./map.sh -c ${CLUSTER} ${JOBSTORE} ${OUTSTORE}/HGSVC/map-HG00514 s3://${OUTSTORE}/HGSVC/HGSVC HG00514 ${FQBASE}/HG00514/ERR903030_1.fastq.gz ${FQBASE}/HG00514/ERR903030_2.fastq.gz 
 ./map.sh -c ${CLUSTER} ${JOBSTORE} ${OUTSTORE}/HGSVC/map-HG00733 s3://${OUTSTORE}/HGSVC/HGSVC HG00733 ${FQBASE}/HG00733/ERR895347_1.fastq.gz ${FQBASE}/HG00733/ERR895347_2.fastq.gz
 ./map.sh -c ${CLUSTER} ${JOBSTORE} ${OUTSTORE}/HGSVC/map-NA19240 s3://${OUTSTORE}/HGSVC/HGSVC NA19240 ${FQBASE}/NA19240/ERR894724_1.fastq.gz ${FQBASE}/NA19240/ERR894724_2.fastq.gz
 
-./call.sh -c ${CLUSTER} -v s3://${OUTSTORE}/HGSVC/HGSVC.haps.vcf.gz -l s3://${OUTSTORE}/HGSVC/HGSVC_alts.gam ${JOBSTORE} ${OUTSTORE}/HGSVC/call-HG00514 s3://${OUTSTORE}/HGSVC/HGSVC.xg HG00514 s3://${OUTSTORE}/HGSVC/map-HG00514/HG00514_chr
-./call.sh -c ${CLUSTER} -v s3://${OUTSTORE}/HGSVC/HGSVC.haps.vcf.gz -l s3://${OUTSTORE}/HGSVC/HGSVC_alts.gam ${JOBSTORE} ${OUTSTORE}/HGSVC/call-HG00733 s3://${OUTSTORE}/HGSVC/HGSVC.xg HG00733 s3://${OUTSTORE}/HGSVC/map-HG00733/HG00733_chr
-./call.sh -c ${CLUSTER} -v s3://${OUTSTORE}/HGSVC/HGSVC.haps.vcf.gz -l s3://${OUTSTORE}/HGSVC/HGSVC_alts.gam ${JOBSTORE} ${OUTSTORE}/HGSVC/call-NA19240 s3://${OUTSTORE}/HGSVC/HGSVC.xg NA19240 s3://${OUTSTORE}/HGSVC/map-NA19240/NA19240_chr
+./call.sh -c ${CLUSTER} -v s3://${OUTSTORE}/HGSVC/HGSVC.haps.vcf.gz ${JOBSTORE} ${OUTSTORE}/HGSVC/call-HG00514 s3://${OUTSTORE}/HGSVC/HGSVC.xg HG00514 s3://${OUTSTORE}/HGSVC/map-HG00514/HG00514_chr
+./call.sh -c ${CLUSTER} -v s3://${OUTSTORE}/HGSVC/HGSVC.haps.vcf.gz ${JOBSTORE} ${OUTSTORE}/HGSVC/call-HG00733 s3://${OUTSTORE}/HGSVC/HGSVC.xg HG00733 s3://${OUTSTORE}/HGSVC/map-HG00733/HG00733_chr
+./call.sh -c ${CLUSTER} -v s3://${OUTSTORE}/HGSVC/HGSVC.haps.vcf.gz ${JOBSTORE} ${OUTSTORE}/HGSVC/call-NA19240 s3://${OUTSTORE}/HGSVC/HGSVC.xg NA19240 s3://${OUTSTORE}/HGSVC/map-NA19240/NA19240_chr
 
 # vg call no longer needs toil-vg
 # for the timing benchmarks in the paper, it was run directly on the whole genome output (GAM created by catting chromosome gams together)

--- a/human/svpop/README.md
+++ b/human/svpop/README.md
@@ -39,9 +39,9 @@ Using the helper scripts from `../toil-scripts`.
 ./map.sh -c ${CLUSTER} ${JOBSTORE} ${OUTSTORE}/SVPOP/map-HG00733 s3://${OUTSTORE}/SVPOP/SVPOP HG00733 ${FQBASE}/HG00733/ERR895347_1.fastq.gz ${FQBASE}/HG00733/ERR895347_2.fastq.gz
 ./map.sh -c ${CLUSTER} ${JOBSTORE} ${OUTSTORE}/SVPOP/map-NA19240 s3://${OUTSTORE}/SVPOP/SVPOP NA19240 ${FQBASE}/NA19240/ERR894724_1.fastq.gz ${FQBASE}/NA19240/ERR894724_2.fastq.gz
 
-./call.sh -c ${CLUSTER} -v s3://${OUTSTORE}/SVPOP/sv-pop-explicit.vcf.gz -l s3://${OUTSTORE}/SVPOP/SVPOP_alts.gam ${JOBSTORE} ${OUTSTORE}/SVPOP/call-HG00514 s3://${OUTSTORE}/SVPOP/SVPOP.xg HG00514 s3://${OUTSTORE}/SVPOP/map-HG00514/HG00514_chr
-./call.sh -c ${CLUSTER} -v s3://${OUTSTORE}/SVPOP/sv-pop-explicit.vcf.gz -l s3://${OUTSTORE}/SVPOP/SVPOP_alts.gam ${JOBSTORE} ${OUTSTORE}/SVPOP/call-HG00733 s3://${OUTSTORE}/SVPOP/SVPOP.xg HG00733 s3://${OUTSTORE}/SVPOP/map-HG00733/HG00733_chr
-./call.sh -c ${CLUSTER} -v s3://${OUTSTORE}/SVPOP/sv-pop-explicit.vcf.gz -l s3://${OUTSTORE}/SVPOP/SVPOP_alts.gam ${JOBSTORE} ${OUTSTORE}/SVPOP/call-NA19240 s3://${OUTSTORE}/SVPOP/SVPOP.xg NA19240 s3://${OUTSTORE}/SVPOP/map-NA19240/NA19240_chr
+./call.sh -c ${CLUSTER} -v s3://${OUTSTORE}/SVPOP/sv-pop-explicit.vcf.gz ${JOBSTORE} ${OUTSTORE}/SVPOP/call-HG00514 s3://${OUTSTORE}/SVPOP/SVPOP.xg HG00514 s3://${OUTSTORE}/SVPOP/map-HG00514/HG00514_chr
+./call.sh -c ${CLUSTER} -v s3://${OUTSTORE}/SVPOP/sv-pop-explicit.vcf.gz ${JOBSTORE} ${OUTSTORE}/SVPOP/call-HG00733 s3://${OUTSTORE}/SVPOP/SVPOP.xg HG00733 s3://${OUTSTORE}/SVPOP/map-HG00733/HG00733_chr
+./call.sh -c ${CLUSTER} -v s3://${OUTSTORE}/SVPOP/sv-pop-explicit.vcf.gz ${JOBSTORE} ${OUTSTORE}/SVPOP/call-NA19240 s3://${OUTSTORE}/SVPOP/SVPOP.xg NA19240 s3://${OUTSTORE}/SVPOP/map-NA19240/NA19240_chr
 
 # vg call no longer needs toil-vg
 # for the timing benchmarks in the paper, it was run directly on the whole genome output (GAM created by catting chromosome gams together)

--- a/human/toil-scripts/README.md
+++ b/human/toil-scripts/README.md
@@ -3,12 +3,12 @@ The commands for each dataset are located in their dedicated folder (e.g. `../hg
 
 ## Setup
 
-toil-vg commit 8f2dbe265689db2ac8b554c3c6f1458372ac6ec3 (or newer) can be used, with its default vg docker image
+toil-vg commit ed586234e970f13f38dddc45ce2a189a9b76e020 (or newer) can be used, with its default vg docker image
 ```
 virtualenv toilvenv
 source toilvenv/bin/activate
 pip install toil[aws,mesos]==3.20.0
-pip install toil-vg git+https://github.com/vgteam/toil-vg.git@1f54b04243e633640f7bae8ef2f35a90f5f75148
+pip install toil-vg git+https://github.com/vgteam/toil-vg.git@ed586234e970f13f38dddc45ce2a189a9b76e020
 ```
 
 The following environment variables need to be set


### PR DESCRIPTION
This gets calling working in the spot check.  Still better to use vg directly (commands given in paper and readme here) but at least toil-vg call as described will work.